### PR TITLE
Fix missing installed tools during kernel compilation

### DIFF
--- a/docs/rock5/lowlevel-development/build_kernel.md
+++ b/docs/rock5/lowlevel-development/build_kernel.md
@@ -11,7 +11,7 @@ sidebar_position: 60
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y git  device-tree-compiler libncurses5 libncurses5-dev build-essential libssl-dev mtools bc python dosfstools bison flex rsync u-boot-tools make mtools
+sudo apt-get install git device-tree-compiler libncurses5 libncurses5-dev build-essential libssl-dev mtools bc python3 dosfstools bison flex rsync u-boot-tools make -y
 ```
 
 ## 获取源代码

--- a/docs/rock5/lowlevel-development/build_kernel.md
+++ b/docs/rock5/lowlevel-development/build_kernel.md
@@ -11,7 +11,7 @@ sidebar_position: 60
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y git  device-tree-compiler libncurses5 libncurses5-dev build-essential libssl-dev mtools bc python dosfstools bison flex rsync u-boot-tools make
+sudo apt-get install -y git  device-tree-compiler libncurses5 libncurses5-dev build-essential libssl-dev mtools bc python dosfstools bison flex rsync u-boot-tools make mtools
 ```
 
 ## 获取源代码


### PR DESCRIPTION
在编译内核的时候，制作镜像的脚本会用到mmd命令，这个由mtools提供，测试armbian的ub server并不会自带这个包，所以会找不到命令