### PR TITLE
Make link to productlist page absolute

### DIFF
--- a/docs/general-tutorial/os-installation.md
+++ b/docs/general-tutorial/os-installation.md
@@ -21,7 +21,7 @@ import TabItem from '@theme/TabItem';
 
 1. 准备一个 microSD 卡
 2. 准备一个 SD 卡读卡器
-3. 下载[对应产品](../productlist)的官方 Ubuntu / Debian 系统镜像
+3. 下载[对应产品](/productlist)的官方 Ubuntu / Debian 系统镜像
 4. 把 SD 卡插入 SD 读卡器, 然后把 SD 读卡器插入计算机的 USB 接口
 
 ### 刷入操作系统镜像到 microSD 卡
@@ -74,7 +74,7 @@ import TabItem from '@theme/TabItem';
 
 ![Radxa eMMC](/img/accessories/emmc_related_01.webp)
 
-- 下载[对应产品](../productlist)的官方系统镜像。
+- 下载[对应产品](/productlist)的官方系统镜像。
 - [下载](https://etcher.balena.io/)刷写工具 `Etcher` 。
   ![ROCK5A via Etcher](/img/rock5a/rock5a-etcher.webp)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/general-tutorial/os-installation.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/general-tutorial/os-installation.md
@@ -21,7 +21,7 @@ import TabItem from '@theme/TabItem';
 
 1. Prepare a microSD card
 2. Prepare an SD card reader
-3. Download [corresponding product](productlist) of the official Ubuntu / Debian system image
+3. Download [corresponding product](/productlist) of the official Ubuntu / Debian system image
 4. Insert the SD card into the SD card reader, then insert the SD card reader into the USB port of the computer
 
 ### Flash OS image to microSD card
@@ -73,7 +73,7 @@ This tutorial is only applicable to write removable eMMC modules, onboard eMMCs 
 
 ![Radxa eMMC](/img/accessories/emmc_related_01.webp)
 
-- Download the [corresponding product](../productlist) for the official Ubuntu / Debian system image.
+- Download the [corresponding product](/productlist) for the official Ubuntu / Debian system image.
 - [Download](https://etcher.balena.io/) flash tool `Etcher`.  
   ![ROCK5A via Etcher](/img/rock5a/rock5a-etcher.webp)
 


### PR DESCRIPTION
###### Description of changes

Fix the broken `productlist` link in English documentation, and while we are on it, also update other links to be absolute.

###### Review guide

<!--
The below instructions are for the reviewer only.
Do not delete them!
-->

To review this PR locally, please run the following commands:

```bash
PR= # the current PR number
git fetch origin pull/${PR}/head
git switch --detach FETCH_HEAD
yarn start
yarn start --locale en
# If you want to start 2 locales side-by-side, use the following command on Linux:
# https://github.com/facebook/docusaurus/issues/7377#issuecomment-1167192715
yarn start & DOCUSAURUS_GENERATED_FILES_DIR_NAME=.docusaurus/en yarn start --locale en --port 3001
kill %1
```
