### PR TITLE
Publishing pages is not mandatory

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,14 +38,17 @@ jobs:
         run: |
           yarn install
           yarn build
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
           # Upload entire repository
           path: "./build"
+      - name: Setup Pages
+        id: setup-pages
+        uses: actions/configure-pages@v3
+        continue-on-error: true
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
-        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+        if: steps.setup-pages.outcome == 'success'


### PR DESCRIPTION
###### Description of changes

This allows contributor to have their CI completed without the need to enable GitHub Pages manually, as shown [here](https://github.com/CodeChenL/documentation/actions/runs/6247562454).

First reported in #233

###### Review guide

<!--
The below instructions are for the reviewer only.
Do not delete them!
-->

To review this PR locally, please run the following commands:

```bash
PR= # the current PR number
git fetch origin pull/${PR}/head
git switch --detach FETCH_HEAD
yarn start
yarn start --locale en
# If you want to start 2 locales side-by-side, use the following command on Linux:
# https://github.com/facebook/docusaurus/issues/7377#issuecomment-1167192715
yarn start & DOCUSAURUS_GENERATED_FILES_DIR_NAME=.docusaurus/en yarn start --locale en --port 3001
kill %1
```
