### PR TITLE
fix: CI: print the actual pre-commit command run on failure

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -65,7 +65,9 @@ jobs:
             echo ''
             echo '=== Issue detected! ==='
             echo 'Suggest changes are listed above.'
-            echo 'Please install pre-commit and run `pre-commit run --all-files` to fix it.'
+            echo -n 'Please install pre-commit and run `pre-commit run --show-diff-on-failure '
+            echo -n "${EXTRA_ARGS[@]}"
+            echo '` to fix it.'
             echo 'Strongly recommended to run `pre-commit install` to catch issues before pushing.'
             echo 'You can learn more abour pre-commit from https://pre-commit.com/'
             exit 1


### PR DESCRIPTION
###### Description of changes

<!--
Please briefly describe changes made in this PR.
-->

###### Review guide

<!--
The below instructions are for the reviewer only.
Do not delete them!
-->

To review this PR locally, please run the following commands:

```bash
PR= # the current PR number
git fetch origin pull/${PR}/head
git switch --detach FETCH_HEAD
yarn start
yarn start --locale en
# If you want to start 2 locales side-by-side, use the following command on Linux:
# https://github.com/facebook/docusaurus/issues/7377#issuecomment-1167192715
yarn start & DOCUSAURUS_GENERATED_FILES_DIR_NAME=.docusaurus/en yarn start --locale en --port 3001
kill %1
```
