### PR TITLE
fix: pre-commit: exclude .github/CODEOWNERS by gitown

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,11 +48,12 @@ static              @xzuoqi @akgnah
 .github             @RadxaYuntian
 .pre-commit-config.* @CodeChenL @RadxaYuntian
 ####################gitown####################
+.github/CODEOWNERS @radxa-docs/Editor
+.gitownrc @CodeChenL
+.cz.toml @CodeChenL
+####################Others####################
 static/img/rock3/Rock3C-bottom-800px.webp @Maycides
 docs/rock3/rock3c/os-config/rsetup.md @u7985
-.gitownrc @CodeChenL
-.github/CODEOWNERS @CodeChenL @nascs
-.cz.toml @CodeChenL
 src/components/CustomDocItem/Footer/styles.module.css @xzuoqi
 i18n/en/docusaurus-plugin-content-docs/current/rock5/rock5b/low-level-dev/README.md @u7985
 i18n/en/docusaurus-plugin-content-docs/current/rock3/rock3a/os-config/rsetup.md @nascs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,7 @@ repos:
           ]
         stages:
           - manual
+        exclude: .github/CODEOWNERS
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v3.16.0
     hooks:


### PR DESCRIPTION
###### Description of changes

<!--
Please briefly describe changes made in this PR.
-->

###### Review guide

<!--
The below instructions are for the reviewer only.
Do not delete them!
-->

To review this PR locally, please run the following commands:

```bash
PR= # the current PR number
git fetch origin pull/${PR}/head
git switch --detach FETCH_HEAD
yarn start
yarn start --locale en
# If you want to start 2 locales side-by-side, use the following command on Linux:
# https://github.com/facebook/docusaurus/issues/7377#issuecomment-1167192715
yarn start & DOCUSAURUS_GENERATED_FILES_DIR_NAME=.docusaurus/en yarn start --locale en --port 3001
kill %1
```
